### PR TITLE
feat: add node shape overlap check

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "diagram-claude-plugin",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Generate professional diagrams from natural language using the best-fit Python library for each diagram type.",
   "author": {
     "name": "Edmondo Porcu"

--- a/skills/generate-diagram/references/examples/test_fixtures/nodes-overlap.svg
+++ b/skills/generate-diagram/references/examples/test_fixtures/nodes-overlap.svg
@@ -1,25 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <!-- Known-bad fixture: two node shapes intentionally overlap -->
-<svg width="300pt" height="200pt" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
-<g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 196)">
+<svg width="260" height="120" viewBox="0 0 260 120" xmlns="http://www.w3.org/2000/svg">
+<rect width="260" height="120" fill="#f8f9fa"/>
+<g id="graph0" class="graph">
 <title>G</title>
-<!-- Node A: box from (20,100) to (120,150) -->
+<!-- Node A: box from (10,20) to (130,80) -->
 <g id="node1" class="node">
 <title>A</title>
-<polygon fill="#e3f2fd" stroke="#333" points="20,100 120,100 120,150 20,150 20,100"/>
-<text text-anchor="middle" x="70" y="130" font-family="Helvetica" font-size="12">Node A</text>
+<polygon fill="#e3f2fd" stroke="#333" stroke-width="1.5" points="10,20 130,20 130,80 10,80 10,20"/>
+<text text-anchor="middle" x="70" y="55" font-family="Helvetica" font-size="14">Node A</text>
 </g>
-<!-- Node B: box from (80,110) to (180,160) — overlaps Node A -->
+<!-- Node B: box from (90,40) to (250,100) — overlaps Node A -->
 <g id="node2" class="node">
 <title>B</title>
-<polygon fill="#e8f5e9" stroke="#333" points="80,110 180,110 180,160 80,160 80,110"/>
-<text text-anchor="middle" x="130" y="140" font-family="Helvetica" font-size="12">Node B</text>
+<polygon fill="#e8f5e9" stroke="#333" stroke-width="1.5" points="90,40 250,40 250,100 90,100 90,40"/>
+<text text-anchor="middle" x="170" y="75" font-family="Helvetica" font-size="14">Node B</text>
 </g>
 <!-- Dummy edge so it parses as a valid graph -->
 <g id="edge1" class="edge">
 <title>A&#45;&gt;B</title>
-<path fill="none" stroke="#333" d="M120,125C130,125 140,130 150,135"/>
+<path fill="none" stroke="#333" d="M130,50C140,50 150,55 160,60"/>
 </g>
 </g>
 </svg>

--- a/skills/generate-diagram/references/examples/test_fixtures/nodes-overlap.svg
+++ b/skills/generate-diagram/references/examples/test_fixtures/nodes-overlap.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Known-bad fixture: two node shapes intentionally overlap -->
+<svg width="300pt" height="200pt" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
+<g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 196)">
+<title>G</title>
+<!-- Node A: box from (20,100) to (120,150) -->
+<g id="node1" class="node">
+<title>A</title>
+<polygon fill="#e3f2fd" stroke="#333" points="20,100 120,100 120,150 20,150 20,100"/>
+<text text-anchor="middle" x="70" y="130" font-family="Helvetica" font-size="12">Node A</text>
+</g>
+<!-- Node B: box from (80,110) to (180,160) — overlaps Node A -->
+<g id="node2" class="node">
+<title>B</title>
+<polygon fill="#e8f5e9" stroke="#333" points="80,110 180,110 180,160 80,160 80,110"/>
+<text text-anchor="middle" x="130" y="140" font-family="Helvetica" font-size="12">Node B</text>
+</g>
+<!-- Dummy edge so it parses as a valid graph -->
+<g id="edge1" class="edge">
+<title>A&#45;&gt;B</title>
+<path fill="none" stroke="#333" d="M120,125C130,125 140,130 150,135"/>
+</g>
+</g>
+</svg>

--- a/skills/generate-diagram/references/examples/test_svg_quality.py
+++ b/skills/generate-diagram/references/examples/test_svg_quality.py
@@ -89,6 +89,44 @@ def bbox_from_path_d(d: str) -> BBox | None:
     return BBox(min(xs), min(ys), max(xs), max(ys))
 
 
+def ellipse_bbox(elem: ET.Element) -> BBox | None:
+    cx = elem.get("cx")
+    cy = elem.get("cy")
+    rx = elem.get("rx")
+    ry = elem.get("ry")
+    if any(v is None for v in (cx, cy, rx, ry)):
+        return None
+    cx_f, cy_f = float(cx), float(cy)
+    rx_f, ry_f = float(rx), float(ry)
+    return BBox(cx_f - rx_f, cy_f - ry_f, cx_f + rx_f, cy_f + ry_f)
+
+
+def polygon_bbox(elem: ET.Element) -> BBox | None:
+    points = elem.get("points", "")
+    coords = re.findall(r"(-?\d+\.?\d*),(-?\d+\.?\d*)", points)
+    if not coords:
+        return None
+    xs = [float(c[0]) for c in coords]
+    ys = [float(c[1]) for c in coords]
+    return BBox(min(xs), min(ys), max(xs), max(ys))
+
+
+def node_shape_bbox(g: ET.Element) -> BBox | None:
+    for tag, extractor in [("ellipse", ellipse_bbox), ("polygon", polygon_bbox)]:
+        el = g.find(tag)
+        if el is not None:
+            bb = extractor(el)
+            if bb:
+                return bb
+    path_el = g.find("path")
+    if path_el is not None:
+        d = path_el.get("d", "")
+        bb = bbox_from_path_d(d)
+        if bb:
+            return bb
+    return None
+
+
 def text_bbox(elem: ET.Element) -> BBox | None:
     x_str = elem.get("x")
     y_str = elem.get("y")
@@ -124,6 +162,7 @@ class ParsedSVG:
     cluster_labels: dict[str, tuple[str, BBox]]
     cluster_border_paths: dict[str, str]  # cluster name → raw d attribute
     node_labels: list[tuple[str, BBox]]
+    node_shapes: list[tuple[str, BBox]]  # (node_name, shape bounding box)
     edge_labels: list[tuple[str, str, BBox]]  # (display_name, edge_id, bbox)
     edge_paths: list[tuple[str, str]]  # (edge_id, raw d attribute)
 
@@ -162,6 +201,7 @@ def parse_svg(svg_path: Path) -> ParsedSVG:
                 cluster_labels[name] = (text_el.text or "", tb)
 
     node_labels: list[tuple[str, BBox]] = []
+    node_shapes: list[tuple[str, BBox]] = []
     for g in graph_g.findall(".//g[@class='node']"):
         title = g.find("title")
         node_name = title.text if title is not None and title.text else "?"
@@ -170,6 +210,9 @@ def parse_svg(svg_path: Path) -> ParsedSVG:
             tb = text_bbox(text_el)
             if tb:
                 node_labels.append((node_name, tb))
+        shape_bb = node_shape_bbox(g)
+        if shape_bb:
+            node_shapes.append((node_name, shape_bb))
 
     edge_labels: list[tuple[str, str, BBox]] = []
     edge_paths: list[tuple[str, str]] = []
@@ -193,6 +236,7 @@ def parse_svg(svg_path: Path) -> ParsedSVG:
         cluster_labels,
         cluster_border_paths,
         node_labels,
+        node_shapes,
         edge_labels,
         edge_paths,
     )
@@ -331,6 +375,16 @@ def check_edge_label_distance(
     return errors
 
 
+def check_node_shape_overlaps(svg: ParsedSVG) -> list[str]:
+    """No two node shapes may overlap each other."""
+    errors: list[str] = []
+    for i, (name_a, bb_a) in enumerate(svg.node_shapes):
+        for name_b, bb_b in svg.node_shapes[i + 1 :]:
+            if bb_a.overlaps(bb_b):
+                errors.append(f"Node shapes overlap: '{name_a}' vs '{name_b}'")
+    return errors
+
+
 def run_all_checks(svg: ParsedSVG) -> list[str]:
     errors: list[str] = []
     errors.extend(check_arrow_crosses_any_text(svg))
@@ -338,6 +392,7 @@ def run_all_checks(svg: ParsedSVG) -> list[str]:
     errors.extend(check_data_layer_position(svg))
     errors.extend(check_label_overlaps(svg))
     errors.extend(check_edge_label_distance(svg))
+    errors.extend(check_node_shape_overlaps(svg))
     return errors
 
 
@@ -370,6 +425,10 @@ class TestOutputDiagram:
 
     def test_no_label_overlaps(self, svg: ParsedSVG) -> None:
         errors = check_label_overlaps(svg)
+        assert not errors, "\n".join(errors)
+
+    def test_no_node_shape_overlaps(self, svg: ParsedSVG) -> None:
+        errors = check_node_shape_overlaps(svg)
         assert not errors, "\n".join(errors)
 
 


### PR DESCRIPTION
## Summary

- Adds `check_node_shape_overlaps` to the SVG quality validator — detects when two node shapes overlap each other
- Extracts bounding boxes from `<polygon>`, `<ellipse>`, and `<path>` elements within `<g class="node">` groups
- Adds `nodes-overlap.svg` known-bad fixture that must fail the new check
- Bumps version from 0.3.5 to 0.3.6

## Test plan

- [x] New fixture `nodes-overlap.svg` correctly triggers overlap detection
- [x] All 13 tests pass (5 output diagram checks + 8 fixture-must-fail checks)
- [x] Existing fixtures and checks are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)