### PR TITLE
feat: add solid-border text overlap and z-order occlusion checks

### DIFF
--- a/packages/diagram-testkit/pyproject.toml
+++ b/packages/diagram-testkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "diagram-testkit"
-version = "0.5.0"
+version = "0.6.0"
 description = "SVG quality linter for generated diagrams"
 requires-python = ">=3.10"
 license = "MIT"

--- a/packages/diagram-testkit/src/diagram_testkit/checks.py
+++ b/packages/diagram-testkit/src/diagram_testkit/checks.py
@@ -338,6 +338,7 @@ def _point_in_bbox(x: float, y: float, bb: BBox) -> bool:
 
 PATH_ENDPOINT_INSET = 4.0  # px — endpoint must be this far inside to count
 CLUSTER_BORDER_TEXT_PADDING = 3.0  # px buffer around dashed border
+SOLID_BORDER_TEXT_PADDING = 3.0  # px buffer around solid border
 CHILD_RECT_MIN_MARGIN = 2.0  # px minimum gap between child and parent rect
 
 
@@ -518,6 +519,98 @@ def check_child_rect_clips_parent(
     return errors
 
 
+def check_text_on_solid_border(
+    svg_path: Path,
+    *,
+    padding: float = SOLID_BORDER_TEXT_PADDING,
+) -> list[str]:
+    tree = ET.parse(svg_path)
+    root = tree.getroot()
+    for elem in root.iter():
+        if "}" in elem.tag:
+            elem.tag = elem.tag.split("}", 1)[1]
+
+    solid_rects: list[tuple[BBox, float]] = []
+    for rect_el in root.iter("rect"):
+        if rect_el.get("stroke-dasharray"):
+            continue
+        rb = _parse_rect_bbox(rect_el)
+        if rb is None:
+            continue
+        stroke = rect_el.get("stroke")
+        if not stroke or stroke == "none":
+            continue
+        stroke_w = float(rect_el.get("stroke-width", "2"))
+        solid_rects.append((rb, stroke_w))
+
+    text_labels: list[tuple[str, BBox]] = []
+    for text_el in root.iter("text"):
+        content = text_el.text or ""
+        if not content.strip():
+            continue
+        tb = text_bbox(text_el)
+        if tb is not None:
+            text_labels.append((content.strip(), tb))
+
+    errors: list[str] = []
+    for label, tb in text_labels:
+        text_poly = tb.to_shapely()
+        text_cy = (tb.y_min + tb.y_max) / 2
+        for rb, stroke_w in solid_rects:
+            # Skip text whose center is clearly inside the rect (it's a label)
+            if (rb.x_min + padding < tb.cx < rb.x_max - padding
+                    and rb.y_min + padding < text_cy < rb.y_max - padding):
+                continue
+            border = rb.to_shapely().boundary.buffer(stroke_w / 2 + padding)
+            if text_poly.intersects(border):
+                errors.append(
+                    f"Text '{label}' overlaps solid rect border"
+                )
+
+    return errors
+
+
+def check_text_occluded_by_rect(
+    svg_path: Path,
+) -> list[str]:
+    tree = ET.parse(svg_path)
+    root = tree.getroot()
+    for elem in root.iter():
+        if "}" in elem.tag:
+            elem.tag = elem.tag.split("}", 1)[1]
+
+    # Walk elements in document order, tracking text elements seen so far
+    preceding_texts: list[tuple[str, BBox]] = []
+    errors: list[str] = []
+
+    for elem in root.iter():
+        if elem.tag == "text":
+            content = elem.text or ""
+            if not content.strip():
+                continue
+            tb = text_bbox(elem)
+            if tb is not None:
+                preceding_texts.append((content.strip(), tb))
+        elif elem.tag == "rect":
+            fill = elem.get("fill", "")
+            if not fill or fill == "none" or fill == "transparent":
+                continue
+            rb = _parse_rect_bbox(elem)
+            if rb is None:
+                continue
+            for label, tb in preceding_texts:
+                if (rb.x_min <= tb.x_min
+                        and rb.y_min <= tb.y_min
+                        and rb.x_max >= tb.x_max
+                        and rb.y_max >= tb.y_max):
+                    errors.append(
+                        f"Text '{label}' occluded by later rect "
+                        f"(fill={fill})"
+                    )
+
+    return errors
+
+
 def check_text_outside_viewport(
     svg_path: Path,
     *,
@@ -588,4 +681,6 @@ def run_all_checks_with_file(
         errors.extend(check_path_endpoint_inside_rect(svg_path))
         errors.extend(check_text_on_cluster_border(svg_path))
         errors.extend(check_child_rect_clips_parent(svg_path))
+        errors.extend(check_text_on_solid_border(svg_path))
+        errors.extend(check_text_occluded_by_rect(svg_path))
     return errors

--- a/packages/diagram-testkit/tests/fixtures/border-and-occlusion-faults.svg
+++ b/packages/diagram-testkit/tests/fixtures/border-and-occlusion-faults.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300">
+<!-- Background -->
+<rect x="0" y="0" width="400" height="300" fill="#FAFAFA" />
+
+<!-- Bug 1: Text sitting on the bottom border of a solid-bordered rect.
+     The rect bottom edge is at y=150 (y=50 + height=100).
+     The text baseline is at y=150, so the text bbox (y=140..150) sits
+     right on the border. -->
+<rect x="30" y="50" width="200" height="100" fill="#E3F2FD" stroke="#5C6BC0" stroke-width="2" />
+<text x="30" y="100" font-size="10">Component A</text>
+<text x="30" y="153" font-size="10">Border Label</text>
+
+<!-- Bug 2: Z-order occlusion — filled rect drawn AFTER text covers it.
+     The text "Hidden Title" is drawn first at y=210 (bbox y=200..210).
+     Then a filled rect is drawn on top, covering that region. -->
+<text x="50" y="210" font-size="10">Hidden Title</text>
+<rect x="40" y="195" width="180" height="80" fill="#E8F5E9" stroke="#66BB6A" stroke-width="2" />
+<text x="50" y="250" font-size="10">Component B</text>
+</svg>

--- a/packages/diagram-testkit/tests/test_border_occlusion.py
+++ b/packages/diagram-testkit/tests/test_border_occlusion.py
@@ -1,0 +1,67 @@
+"""Tests for solid-border text overlap and z-order occlusion checks."""
+
+from pathlib import Path
+
+from diagram_testkit.checks import check_text_occluded_by_rect
+from diagram_testkit.checks import check_text_on_solid_border
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+PASSING_DIR = FIXTURES_DIR / "passing"
+
+
+class TestTextOnSolidBorder:
+
+    def test_text_on_solid_border_detected(self):
+        errors = check_text_on_solid_border(
+            FIXTURES_DIR / "border-and-occlusion-faults.svg",
+        )
+        border_errors = [e for e in errors if "Border Label" in e]
+        assert border_errors, (
+            f"Expected 'Border Label' to overlap solid rect border, "
+            f"got: {errors}"
+        )
+
+    def test_text_inside_rect_not_flagged(self):
+        errors = check_text_on_solid_border(
+            FIXTURES_DIR / "border-and-occlusion-faults.svg",
+        )
+        inside_errors = [e for e in errors if "Component A" in e]
+        assert not inside_errors, (
+            f"'Component A' is inside the rect and should not be flagged, "
+            f"got: {errors}"
+        )
+
+    def test_text_far_from_solid_border_passes(self):
+        errors = check_text_on_solid_border(
+            PASSING_DIR / "text-inside-viewport.svg",
+        )
+        assert not errors
+
+
+class TestTextOccludedByRect:
+
+    def test_occluded_text_detected(self):
+        errors = check_text_occluded_by_rect(
+            FIXTURES_DIR / "border-and-occlusion-faults.svg",
+        )
+        occluded_errors = [e for e in errors if "Hidden Title" in e]
+        assert occluded_errors, (
+            f"Expected 'Hidden Title' to be flagged as occluded, "
+            f"got: {errors}"
+        )
+
+    def test_text_after_rect_not_flagged(self):
+        errors = check_text_occluded_by_rect(
+            FIXTURES_DIR / "border-and-occlusion-faults.svg",
+        )
+        after_errors = [e for e in errors if "Component B" in e]
+        assert not after_errors, (
+            f"'Component B' is drawn after its rect and should not be "
+            f"flagged as occluded, got: {errors}"
+        )
+
+    def test_unfilled_rect_does_not_occlude(self):
+        errors = check_text_occluded_by_rect(
+            PASSING_DIR / "text-inside-viewport.svg",
+        )
+        assert not errors

--- a/packages/diagram-testkit/uv.lock
+++ b/packages/diagram-testkit/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "diagram-testkit"
-version = "0.1.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "shapely" },
@@ -42,7 +42,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
Add two new SVG quality checks to diagram-testkit:

- check_text_on_solid_border: detects text whose bbox intersects the border of a solid-bordered rect (complements the existing dashed-border check). Skips text clearly inside the rect.

- check_text_occluded_by_rect: detects text drawn before a filled rect in SVG document order, where the rect fully covers the text bbox — meaning the rect visually hides the text due to SVG painter's model.

Both checks are wired into run_all_checks_with_file. Includes a minimal hand-written fixture SVG and 6 new pytest cases.

Bumps version from 0.5.0 to 0.6.0.